### PR TITLE
Minor fixes to current workflow

### DIFF
--- a/src/Zend/Expressive/Composer/OptionalPackages.php
+++ b/src/Zend/Expressive/Composer/OptionalPackages.php
@@ -192,8 +192,8 @@ class OptionalPackages
         }
 
         $destinationPath = dirname($projectRoot . $target);
-        if (!is_dir($destinationPath)) {
-            mkdir($destinationPath, 644, true);
+        if (! is_dir($destinationPath)) {
+            mkdir($destinationPath, 0775, true);
         }
 
         $io->write(sprintf("  - Copying <info>%s</info>", $target));

--- a/src/Zend/Expressive/Composer/OptionalPackages.php
+++ b/src/Zend/Expressive/Composer/OptionalPackages.php
@@ -28,9 +28,9 @@ class OptionalPackages
 {
     const PACKAGE_REGEX = '/^(?P<name>[^:]+\/[^:]+)([:]*)(?P<version>.*)$/';
 
-    static $composerDefinition;
+    private static $composerDefinition;
 
-    static $composerRequires;
+    private static $composerRequires;
 
     /**
      * @param Event $event
@@ -109,26 +109,23 @@ class OptionalPackages
     {
         // Construct question
         $ask = [
-            "\n  <question>" . $question['question'] . "</question>\n"
+            sprintf("\n  <question>%s</question>\n", $question['question']),
         ];
 
         $defaultText = $defaultOption;
+
         foreach ($question['options'] as $key => $option) {
-            if ($key == $defaultOption) {
-                $defaultText = $option['name'];
-            }
-            $ask[] = sprintf("  [<comment>%d</comment>] %s\n", $key, $option['name']);
+            $defaultText = ($key === $defaultOption) ? $option['name'] : $defaultText;
+            $ask[]       = sprintf("  [<comment>%d</comment>] %s\n", $key, $option['name']);
         }
 
         if ($question['required'] !== true) {
             $ask[] = "  [<comment>n</comment>] None of the above\n";
         }
 
-        if ($question['custom-package'] === true) {
-            $ask[] = sprintf("  Make your selection or type a composer package name and version <comment>(%s)</comment>: ", $defaultText);
-        } else {
-            $ask[] = sprintf("  Make your selection <comment>(%s)</comment>: ", $defaultText);
-        }
+        $ask[] = ($question['custom-package'] === true)
+            ? sprintf("  Make your selection or type a composer package name and version <comment>(%s)</comment>: ", $defaultText)
+            : sprintf("  Make your selection <comment>(%s)</comment>: ", $defaultText);
 
         while (true) {
             // Ask for user input
@@ -146,10 +143,10 @@ class OptionalPackages
 
             // Search for package
             if ($question['custom-package'] === true && preg_match(self::PACKAGE_REGEX, $answer, $match)) {
-                $packageName = $match['name'];
+                $packageName    = $match['name'];
                 $packageVersion = $match['version'];
 
-                if (!$packageVersion) {
+                if (! $packageVersion) {
                     $io->write("<error>No package version specified</error>");
                     continue;
                 }
@@ -157,7 +154,7 @@ class OptionalPackages
                 $io->write(sprintf("  - Searching for <info>%s:%s</info>", $packageName, $packageVersion));
 
                 $optionalPackage = $composer->getRepositoryManager()->findPackage($packageName, $packageVersion);
-                if (!$optionalPackage) {
+                if (! $optionalPackage) {
                     $io->write(sprintf("<error>Package not found %s:%s</error>", $packageName, $packageVersion));
                     continue;
                 }
@@ -166,7 +163,6 @@ class OptionalPackages
             }
 
             $io->write("<error>Invalid answer</error>");
-            continue;
         }
 
         return false;
@@ -197,7 +193,7 @@ class OptionalPackages
 
         $destinationPath = dirname($projectRoot . $target);
         if (!is_dir($destinationPath)) {
-            mkdir($destinationPath, 644);
+            mkdir($destinationPath, 644, true);
         }
 
         $io->write(sprintf("  - Copying <info>%s</info>", $target));

--- a/src/Zend/Expressive/Composer/config.php
+++ b/src/Zend/Expressive/Composer/config.php
@@ -2,101 +2,100 @@
 
 return [
     'packages' => [
-        'aura/router' => '^2.3',
-        'league/plates' => '^3.1',
-        'mouf/pimple-interop' => '^1.0',
-        'nikic/fast-route' => '^0.6.0',
-        'twig/twig' => '^1.19',
-        'zendframework/zend-mvc' => '^2.5',
-        'zendframework/zend-psr7bridge' => '^0.1.0',
+        'aura/router'                       => '^2.3',
+        'league/plates'                     => '^3.1',
+        'mouf/pimple-interop'               => '^1.0',
+        'nikic/fast-route'                  => '^0.6.0',
+        'twig/twig'                         => '^1.19',
+        'zendframework/zend-mvc'            => '^2.5',
+        'zendframework/zend-psr7bridge'     => '^0.1.0',
         'zendframework/zend-servicemanager' => '^2.5',
-        'zendframework/zend-view' => '^2.5',
+        'zendframework/zend-view'           => '^2.5',
     ],
 
     'questions' => [
-
         'router' => [
-            'question' => 'Which router you want to use?',
-            'required' => true, // TRUE: Must choose one / FALSE: May choose one or none of the above
-            'custom-package' => true, // Enable custom package input
+            'question'               => 'Which router you want to use?',
+            'required'               => true, // TRUE: Must choose one / FALSE: May choose one or none of the above
+            'custom-package'         => true, // Enable custom package input
             'custom-package-warning' => 'You need to write your own router adapter.', // Display warning when choosing a custom package
-            'options' => [
+            'options'                => [
                 1 => [
-                    'name' => 'aura/router',
+                    'name'     => 'aura/router',
                     'packages' => [
-                        'aura/router'
+                        'aura/router',
                     ],
                     'copy-files' => [
-                        '/Resources/config/aura-router.php' => '/config/autoload/router.global.php' // Copy source file to target
-                    ]
+                        '/Resources/config/aura-router.php' => '/config/autoload/router.global.php', // Copy source file to target
+                    ],
                 ],
                 2 => [
-                    'name' => 'nikic/fast-route',
+                    'name'     => 'nikic/fast-route',
                     'packages' => [
-                        'nikic/fast-route'
-                    ]
+                        'nikic/fast-route',
+                    ],
                 ],
                 3 => [
-                    'name' => 'zend-mvc TreeRouteStack',
+                    'name'     => 'zend-mvc TreeRouteStack',
                     'packages' => [
                         'zendframework/zend-mvc',
-                        'zendframework/zend-psr7bridge'
-                    ]
-                ]
-            ]
+                        'zendframework/zend-psr7bridge',
+                    ],
+                ],
+            ],
         ],
 
         'container' => [
-            'question' => 'Which container you want to use for dependency injection?',
-            'required' => true,
-            'custom-package' => true,
+            'question'               => 'Which container you want to use for dependency injection?',
+            'required'               => true,
+            'custom-package'         => true,
             'custom-package-warning' => 'You need to edit public/index.php to start the custom container.',
-            'options' => [
+            'options'                => [
                 1 => [
-                    'name' => 'zendframework/zend-servicemanager',
+                    'name'     => 'zendframework/zend-servicemanager',
                     'packages' => [
-                        'zendframework/zend-servicemanager'
+                        'zendframework/zend-servicemanager',
                     ],
                     'copy-files' => [
-                        '/Resources/public/zend-index.php' => '/public/index.php'
-                    ]
+                        '/Resources/public/zend-index.php' => '/public/index.php',
+                    ],
                 ],
                 2 => [
-                    'name' => 'mouf/pimple-interop',
+                    'name'     => 'mouf/pimple-interop',
                     'packages' => [
-                        'mouf/pimple-interop'
+                        'mouf/pimple-interop',
                     ],
                     'copy-files' => [
-                        '/Resources/public/pimple-index.php' => '/public/index.php'
-                    ]
-                ]
-            ]
+                        '/Resources/public/pimple-index.php' => '/public/index.php',
+                    ],
+                ],
+            ],
         ],
 
         'template-engine' => [
-            'question' => 'Which template engine you want to use?',
-            'required' => false,
-            'custom-package' => false,
-            'options' => [
+            'question'       => 'Which template engine you want to use?',
+            'required'       => false,
+            'custom-package' => true,
+            'options'        => [
                 1 => [
-                    'name' => 'zendframework/zend-view',
+                    'name'     => 'zendframework/zend-view',
                     'packages' => [
-                        'zendframework/zend-view'
-                    ]
+                        'zendframework/zend-view',
+                    ],
                 ],
                 2 => [
-                    'name' => 'league/plates',
+                    'name'     => 'league/plates',
                     'packages' => [
-                        'league/plates'
-                    ]
+                        'league/plates',
+                    ],
                 ],
                 3 => [
-                    'name' => 'twig/twig',
+                    'name'     => 'twig/twig',
                     'packages' => [
-                        'twig/twig'
-                    ]
-                ]
-            ]
-        ]
-    ]
+                        'twig/twig',
+                    ],
+                ],
+            ],
+        ],
+    ],
 ];


### PR DESCRIPTION
- Allow adding templates as optional packages.
- `mkdir()` for configuration directory needed to be updated to use `0775` for the mode (otherwise nobody can descend into the directory to write on *nix systems!), and needed the "recursive" flag enabled.

Question for @xtreamwayz: I have one other config change I'd like to make, but I'm not sure it's possible. The default for templating should be "none"; how can I specify that? Is it possible?